### PR TITLE
Bugfix - weight_scores in combine_weighted_scores dropping variants

### DIFF
--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -47,7 +47,6 @@ task weight_scores {
 
         R --vanilla << RSCRIPT
         library(tidyverse)
-        install.packages("R.utils", repos="https://cloud.r-project.org")
         weight_file <- "~{weights}"
         score_file <- "scorefile.txt"
         weights <- read_tsv(weight_file)

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -51,14 +51,19 @@ task weight_scores {
         pgs <- intersect(names(score_vars_head), weights[["score"]])
         cols <- c("ID", "effect_allele", pgs)
         scores <- data.table::fread(score_file, select=cols)
+        print(dim(scores))
+        # Debugging
+        print(sapply(scores, function(x) sum(x != 0)))
         selected_scores <- scores %>%
             filter(!if_all(any_of(pgs), ~ . == 0))
+        print(sapply(selected_scores, function(x) sum(x != 0)))
         rm(scores)
         for (i in 1:nrow(weights)) {
             if (weights[["score"]][i] %in% names(selected_scores)) {
                 selected_scores[[weights[["score"]][i]]] <- selected_scores[[weights[["score"]][i]]] * weights[["weight"]][i]
             }
         }
+        print(sapply(selected_scores, function(x) sum(x != 0)))
         write_tsv(selected_scores, "weighted_scores.txt")
         RSCRIPT
     >>>

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -68,7 +68,7 @@ task weight_scores {
     }
 
     runtime {
-        docker: "rocker/tidyverse:4.5.1"
+        docker: "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
         disks: "local-disk ~{disk_size} SSD"
         memory: "~{mem_gb}G"
     }

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -90,6 +90,8 @@ task combine_scores {
 
     command <<<
         R << RSCRIPT
+        # More debugging
+        options(datatable.verbose=TRUE)
         library(tidyverse)
         weighted_scorefiles <- readLines("~{write_lines(scorefiles)}")
         all_scores <- read_tsv(weighted_scorefiles[1])

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -73,7 +73,7 @@ task weight_scores {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.21.0"
+        docker: "rocker/tidyverse:4.5.1"
         disks: "local-disk ~{disk_size} SSD"
         memory: "~{mem_gb}G"
     }

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -41,7 +41,7 @@ task weight_scores {
     Int disk_size = ceil(3*(size(scorefile, "GB") + size(weights, "GB"))) + 10
 
     command <<<
-        R << RSCRIPT
+        R --vanilla << RSCRIPT
         library(tidyverse)
         install.packages("R.utils", repos="https://cloud.r-project.org")
         weight_file <- "~{weights}"

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -41,14 +41,18 @@ task weight_scores {
     Int disk_size = ceil(3*(size(scorefile, "GB") + size(weights, "GB"))) + 10
 
     command <<<
-        zcat ~{scorefile} | wc -l
+        set -e
+        mv ~{scorefile} scorefile.txt.gz
+        gunzip scorefile.txt.gz
+        wc -l scorefile.txt
+
         R --vanilla << RSCRIPT
         # More debugging
         options(datatable.verbose=TRUE)
         library(tidyverse)
         install.packages("R.utils", repos="https://cloud.r-project.org")
         weight_file <- "~{weights}"
-        score_file <- "~{scorefile}"
+        score_file <- "scorefile.txt"
         weights <- read_tsv(weight_file)
         score_vars_head <- read_tsv(score_file, n_max=10)
         pgs <- intersect(names(score_vars_head), weights[["score"]])

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -41,7 +41,10 @@ task weight_scores {
     Int disk_size = ceil(3*(size(scorefile, "GB") + size(weights, "GB"))) + 10
 
     command <<<
+        zcat ~{scorefile} | wc -l
         R --vanilla << RSCRIPT
+        # More debugging
+        options(datatable.verbose=TRUE)
         library(tidyverse)
         install.packages("R.utils", repos="https://cloud.r-project.org")
         weight_file <- "~{weights}"
@@ -90,8 +93,6 @@ task combine_scores {
 
     command <<<
         R << RSCRIPT
-        # More debugging
-        options(datatable.verbose=TRUE)
         library(tidyverse)
         weighted_scorefiles <- readLines("~{write_lines(scorefiles)}")
         all_scores <- read_tsv(weighted_scorefiles[1])

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -38,7 +38,7 @@ task weight_scores {
         Int mem_gb = 64
     }
 
-    Int disk_size = ceil(3*(size(scorefile, "GB") + size(weights, "GB"))) + 10
+    Int disk_size = ceil(10*(size(scorefile, "GB") + size(weights, "GB"))) + 10
 
     command <<<
         set -e

--- a/combine_weighted_scores.wdl
+++ b/combine_weighted_scores.wdl
@@ -44,11 +44,8 @@ task weight_scores {
         set -e
         mv ~{scorefile} scorefile.txt.gz
         gunzip scorefile.txt.gz
-        wc -l scorefile.txt
 
         R --vanilla << RSCRIPT
-        # More debugging
-        options(datatable.verbose=TRUE)
         library(tidyverse)
         install.packages("R.utils", repos="https://cloud.r-project.org")
         weight_file <- "~{weights}"
@@ -58,18 +55,17 @@ task weight_scores {
         pgs <- intersect(names(score_vars_head), weights[["score"]])
         cols <- c("ID", "effect_allele", pgs)
         scores <- data.table::fread(score_file, select=cols)
-        print(dim(scores))
-        # Debugging
+        print("Initial variant counts:")
         print(sapply(scores, function(x) sum(x != 0)))
         selected_scores <- scores %>%
             filter(!if_all(any_of(pgs), ~ . == 0))
-        print(sapply(selected_scores, function(x) sum(x != 0)))
         rm(scores)
         for (i in 1:nrow(weights)) {
             if (weights[["score"]][i] %in% names(selected_scores)) {
                 selected_scores[[weights[["score"]][i]]] <- selected_scores[[weights[["score"]][i]]] * weights[["weight"]][i]
             }
         }
+        print("Final variant counts:")
         print(sapply(selected_scores, function(x) sum(x != 0)))
         write_tsv(selected_scores, "weighted_scores.txt")
         RSCRIPT


### PR DESCRIPTION
Copy scorefile to disk and unzip before reading.

This is necessary because the size of the temp disk is smaller than then size of the unzipped file, so file is truncated with an informational message that gets hidden in the log. See this issue for more info: https://github.com/Rdatatable/data.table/issues/5095